### PR TITLE
Fix #37 (empty URL caused a bad SQLite request)

### DIFF
--- a/src/org/tint/providers/BookmarksWrapper.java
+++ b/src/org/tint/providers/BookmarksWrapper.java
@@ -391,10 +391,20 @@ public class BookmarksWrapper {
 	public static void updateHistory(ContentResolver contentResolver, String title, String url, String originalUrl) {
 		String[] colums = new String[] { BookmarksProvider.Columns._ID, BookmarksProvider.Columns.URL, BookmarksProvider.Columns.BOOKMARK, BookmarksProvider.Columns.VISITS };
 		
+		if ((url == null || url.length() == 0) && (originalUrl == null || originalUrl.length() == 0))
+			return;
+		
 		String escapedUrl = url != null ? DatabaseUtils.sqlEscapeString(url) : "";
 		String escapedOriginalUrl = originalUrl != null ? DatabaseUtils.sqlEscapeString(originalUrl) : "";
 		
-		String whereClause = BookmarksProvider.Columns.URL + " = " + escapedUrl + " OR " + BookmarksProvider.Columns.URL + " = " + escapedOriginalUrl;
+		String whereClause = ((escapedUrl.length() > 0) ?
+				BookmarksProvider.Columns.URL + " = " + escapedUrl : "") +
+				
+				((escapedUrl.length() > 0 && escapedOriginalUrl.length() > 0) ?
+				" OR " : "") +
+				
+				((escapedOriginalUrl.length() > 0) ?
+				BookmarksProvider.Columns.URL + " = " + escapedOriginalUrl : "");
 
 		Cursor cursor = contentResolver.query(BookmarksProvider.BOOKMARKS_URI, colums, whereClause, null, null);
 


### PR DESCRIPTION
bushrang3r's (#37) example case uses a pop-up to show a calendar, but Tint doesn't keep the base URL -- this is probably not the expected behavior, but that's another issue (to be opened maybe).
Empty URL (and originalURL) caused the SQL query to be `url =  OR url =`, therefore an invalid query.
If both URL and originalURL are empty, the fuctions returns immediately, and "protection" was added to keep the query valid if only one of the two strings are OK.
